### PR TITLE
Make Kiko respect the global page size setting

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <div class="content list h-feed">
 
-{{ $paginator := .Paginate (where .Pages.ByDate.Reverse "Type" "post") (index .Site.Params "archive-paginate" | default 25) }}
+{{ $paginator := .Paginate (where .Pages.ByDate.Reverse "Type" "post") }}
 {{ range $paginator.Pages  }}
 
   <div class="list-item h-entry">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <div class="content list h-feed">
 
-{{ $paginator := .Paginate (where .Site.Pages.ByDate.Reverse "Type" "post") (index .Site.Params "archive-paginate" | default 25) }}
+{{ $paginator := .Paginate (where .Site.Pages.ByDate.Reverse "Type" "post") }}
 {{ range $paginator.Pages  }}
 
   <div class="list-item h-entry">

--- a/layouts/section/replies.html
+++ b/layouts/section/replies.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <div class="content list h-feed">
 
-{{ $paginator := .Paginate (where .Site.Pages.ByDate.Reverse "Type" "reply") (index .Site.Params "archive-paginate" | default 25) }}
+{{ $paginator := .Paginate (where .Site.Pages.ByDate.Reverse "Type" "reply") }}
 {{ range $paginator.Pages  }}
 
   <div class="list-item h-entry">

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"title": "Kiko theme",
 	"description": "Changes your blog to use the Kiko theme."
 }


### PR DESCRIPTION
This one makes Kiko respect the global `paginate` setting in `config.json`. See [discussion over at the Help Center](https://help.micro.blog/t/single-latest-post-on-home-page/1621/7).